### PR TITLE
Deploy org.kframework.dependencies:nailgun-server version 1.0.0

### DIFF
--- a/nailgun-examples/pom.xml
+++ b/nailgun-examples/pom.xml
@@ -1,34 +1,32 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
+  <parent>
     <groupId>org.kframework.dependencies</groupId>
-    <artifactId>nailgun-examples</artifactId>
-    <packaging>jar</packaging>
+    <artifactId>nailgun-all</artifactId>
+    <version>0.9.2-SNAPSHOT</version>
+  </parent>
+ 
+  <artifactId>nailgun-examples</artifactId>
+  <packaging>jar</packaging>
 
-    <name>nailgun-examples</name>
-    <description>
-        Nailgun is a client, protocol, and server for running Java programs from 
-        the command line without incurring the JVM startup overhead. Programs run 
-        in the server (which is implemented in Java), and are triggered by the 
-        client (written in C), which handles all I/O.
-        
-        This project contains the EXAMPLE CODE ONLY.
-    </description>
-    <url>http://martiansoftware.com/nailgun</url>
+  <name>nailgun-examples</name>
+  <description>
+    Nailgun is a client, protocol, and server for running Java programs from 
+    the command line without incurring the JVM startup overhead. Programs run 
+    in the server (which is implemented in Java), and are triggered by the 
+    client (written in C), which handles all I/O.
+    
+    This project contains the EXAMPLE CODE ONLY.
+  </description>
   
-    <parent>
-        <groupId>org.kframework.dependencies</groupId>
-        <artifactId>nailgun-all</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
-    </parent>
-  
-    <dependencies>
-        <dependency>
-            <groupId>org.kframework.dependencies</groupId>
-            <artifactId>nailgun-server</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.kframework.dependencies</groupId>
+      <artifactId>nailgun-server</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/nailgun-examples/pom.xml
+++ b/nailgun-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kframework.dependencies</groupId>
     <artifactId>nailgun-all</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
  
   <artifactId>nailgun-examples</artifactId>

--- a/nailgun-server/pom.xml
+++ b/nailgun-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kframework.dependencies</groupId>
     <artifactId>nailgun-all</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nailgun-server</artifactId>

--- a/nailgun-server/pom.xml
+++ b/nailgun-server/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
     <groupId>net.java.dev.jna</groupId>
     <artifactId>jna</artifactId>
-    <version>4.1.0</version>
+    <version>5.13.0</version>
     </dependency>
   </dependencies>
   

--- a/nailgun-server/pom.xml
+++ b/nailgun-server/pom.xml
@@ -1,52 +1,50 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
+  <parent>
     <groupId>org.kframework.dependencies</groupId>
-    <artifactId>nailgun-server</artifactId>
-    <packaging>jar</packaging>
+    <artifactId>nailgun-all</artifactId>
+    <version>0.9.2-SNAPSHOT</version>
+  </parent>
 
-    <name>nailgun-server</name>
-    <description>
-        Nailgun is a client, protocol, and server for running Java programs from 
-        the command line without incurring the JVM startup overhead. Programs run 
-        in the server (which is implemented in Java), and are triggered by the 
-        client (written in C), which handles all I/O.
-        
-        This project contains the SERVER ONLY.
-    </description>
-    <url>http://martiansoftware.com/nailgun</url>
+  <artifactId>nailgun-server</artifactId>
+  <packaging>jar</packaging>
 
-    <parent>
-        <groupId>org.kframework.dependencies</groupId>
-        <artifactId>nailgun-all</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
-    </parent>
-
-    <dependencies>
-      <dependency>
-        <groupId>net.java.dev.jna</groupId>
-        <artifactId>jna</artifactId>
-        <version>4.1.0</version>
-      </dependency>
-    </dependencies>
+  <name>nailgun-server</name>
+  <description>
+    Nailgun is a client, protocol, and server for running Java programs from 
+    the command line without incurring the JVM startup overhead. Programs run 
+    in the server (which is implemented in Java), and are triggered by the 
+    client (written in C), which handles all I/O.
     
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>com.martiansoftware.nailgun.NGServer</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>  
-    </build>  
+    This project contains the SERVER ONLY.
+  </description>
+
+  <dependencies>
+    <dependency>
+    <groupId>net.java.dev.jna</groupId>
+    <artifactId>jna</artifactId>
+    <version>4.1.0</version>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>com.martiansoftware.nailgun.NGServer</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>  
+  </build>  
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <groupId>org.kframework.dependencies</groupId>
   <artifactId>nailgun-all</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,154 +1,105 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
-	
-    <groupId>org.kframework.dependencies</groupId>
-    <artifactId>nailgun-all</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
-    <packaging>pom</packaging>
-   
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <additionalparam>-Xdoclint:none</additionalparam>
-    </properties>
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
 
-    <name>nailgun-all</name>
-    <description>
-        Nailgun is a client, protocol, and server for running Java programs 
-        from the command line without incurring the JVM startup overhead. 
-        Programs run in the server (which is implemented in Java), and are 
-        triggered by the client (written in C), which handles all I/O.
-    
-        This project contains the server and examples.
-    </description>
-    <url>http://martiansoftware.com/nailgun</url>
+  <groupId>org.kframework.dependencies</groupId>
+  <artifactId>nailgun-all</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>    
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <additionalparam>-Xdoclint:none</additionalparam>
+  </properties>
 
-    <scm>
-        <url>scm:git:git@github.com:martylamb/nailgun.git</url>
-        <connection>scm:git:git@github.com:martylamb/nailgun.git</connection>
-        <developerConnection>scm:git:git@github.com:martylamb/nailgun.git</developerConnection>
-      <tag>nailgun-all-0.9.1</tag>
-  </scm>
+  <name>nailgun-all</name>
+  <description>
+    Nailgun is a client, protocol, and server for running Java programs 
+    from the command line without incurring the JVM startup overhead. 
+    Programs run in the server (which is implemented in Java), and are 
+    triggered by the client (written in C), which handles all I/O.
 
-    <developers>
-        <developer>
-            <email>mlamb@martiansoftware.com</email>
-            <name>Marty Lamb</name>
-            <url>http://martiansoftware.com</url>
-        </developer>
-    </developers>
-	
-    <modules>
-        <module>nailgun-server</module>
-        <module>nailgun-examples</module>
-    </modules>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>        
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-    
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Sonatype Nexus release repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+    This project contains the server and examples.
+  </description>
 
-	<profiles>
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.4</version>
-						<configuration>
-							<passphrase>${gpg.passphrase}</passphrase>
-						</configuration>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-   
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>  
+
+  <modules>
+    <module>nailgun-server</module>
+    <module>nailgun-examples</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <distributionManagement>
+    <repository>
+      <id>runtime.verification</id>
+      <name>Runtime Verification Repository</name>
+      <url>https://runtimeverification.mycloudrepo.io/repositories/runtimeverification</url>
+    </repository>
+    <snapshotRepository>
+      <id>runtime.verification.snapshots</id>
+      <name>Runtime Verification Snapshot Repository</name>
+      <url>https://runtimeverification.mycloudrepo.io/repositories/runtimeverification</url>
+    </snapshotRepository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
This PR merges the changes I made to create a working version of nailgun that is fully maintained by RV rather than existing primarily as a fork of an upstream project.

It's a lot of cleanup to the pom to get to the point where I can deploy just by running `mvn deploy`, plus a few bug fixes.